### PR TITLE
charactertransparency and bugfixes

### DIFF
--- a/FFGear/mtrl_handler.py
+++ b/FFGear/mtrl_handler.py
@@ -16,7 +16,7 @@ logger.setLevel(logging.INFO)
 ###¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤¤###
 
 class MaterialFlags(Flag):
-    HideBackfaces = 0x1
+    RenderBackfaces = 0x1
     Bit1 = 0x2
     Bit2 = 0x4
     Bit3 = 0x8


### PR DESCRIPTION
* Supported shaders are now declared in a tuple at the top of operators.py
* The HideBackfaces flag has been turned into RenderBackfaces because apparently that's what it's meant to be
* The material's surface render method is now set to BLENDED if the shader is charactertransparency.shpk and DITHERED otherwise
* Added a specific warning for if all the materials you're trying to process with the auto meddle setup have already been created